### PR TITLE
Add file extension to types imports (and update caniuse-lite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -8299,9 +8299,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true
     },
     "chalk": {

--- a/src/immutabilityHelpers.ts
+++ b/src/immutabilityHelpers.ts
@@ -9,7 +9,7 @@
  * https://github.com/mariocasciaro/object-path-immutable
  */
 import { isJSONArray, isJSONObject } from './typeguards.js'
-import type { JSONPath } from './types'
+import type { JSONPath } from './types.js'
 import { isObjectOrArray } from './utils.js'
 
 /**

--- a/src/immutableJSONPatch.ts
+++ b/src/immutableJSONPatch.ts
@@ -6,7 +6,7 @@ import type {
   JSONPatchOptions,
   JSONPath,
   JSONPointer
-} from './types'
+} from './types.js'
 import { initial, isEqual, last } from './utils.js'
 
 /**

--- a/src/jsonPointer.ts
+++ b/src/jsonPointer.ts
@@ -1,4 +1,4 @@
-import type { JSONPath, JSONPointer } from './types'
+import type { JSONPath, JSONPointer } from './types.js'
 
 /**
  * Parse a JSON Pointer

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -6,7 +6,7 @@ import type {
   JSONPatchRemove,
   JSONPatchReplace,
   JSONPatchTest
-} from './types'
+} from './types.js'
 
 export function isJSONArray(value: unknown): value is Array<unknown> {
   return Array.isArray(value)


### PR DESCRIPTION
Solves the TypeScript problem encountered in TS 6:

```
node_modules/immutable-json-patch/lib/types/immutabilityHelpers.d.ts:1:31 - error TS2834:
  Relative import paths need explicit file extensions in ECMAScript imports when
  '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the
  import path.

    import type { JSONPath } from './types';
                                  ---------
```

In other places in the code, `types.js` is correctly imported with the file extension. This pull request makes the importing of `types.js` consistent across all files.